### PR TITLE
フォロー解除APIの作成とフォロー取得APIの修正

### DIFF
--- a/backend/api/controller/handler/follow_handler.go
+++ b/backend/api/controller/handler/follow_handler.go
@@ -92,3 +92,31 @@ func (h *FollowHandler) FollowUser(c *gin.Context) {
 
 	c.JSON(http.StatusCreated, gin.H{"message": "Successfully followed user"})
 }
+
+
+func (h *FollowHandler) UnfollowUser(c *gin.Context) {
+	followerIDStr := c.Param("follower_id")
+	followeeIDStr := c.Param("followee_id")
+
+	followerID, err := strconv.Atoi(followerIDStr)
+	if err != nil {
+		fmt.Printf("error reading follower_id param: %v\n", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	followeeID, err := strconv.Atoi(followeeIDStr)
+	if err != nil {
+		fmt.Printf("error reading followee_id param: %v\n", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := h.followService.UnfollowUser(followerID, followeeID); err != nil {
+		fmt.Printf("error unfollowing user (handler): %v\n", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"message": "Successfully unfollowed user"})
+}

--- a/backend/api/controller/server.go
+++ b/backend/api/controller/server.go
@@ -121,6 +121,9 @@ func NewServer() (*gin.Engine, error) {
 
 		// ユーザーをフォローする
 		tag.POST("/follow/:follower_id/:followee_id", followHandler.FollowUser)
+
+		// ユーザーのフォローを外す
+		tag.DELETE("/follow/:follower_id/:followee_id", followHandler.UnfollowUser)
 	}
 
 	for _, route := range r.Routes() {

--- a/backend/api/domain/model/follow.go
+++ b/backend/api/domain/model/follow.go
@@ -8,16 +8,16 @@ import (
 
 type Follow struct {
 	gorm.Model
-	ID         int       `gorm:"primaryKey"`
-	FollowerID int       `gorm:"not null"`
-	FolloweeID int       `gorm:"not null"`
-	CreatedAt  time.Time `gorm:"autoCreateTime"`
-	UpdatedAt  time.Time `gorm:"autoUpdateTime"`
-	DeletedAt  time.Time `gorm:"autoDeleteTime"`
+	ID         int       `gorm:"primaryKey";column:id`
+	FollowerID int       `gorm:"column:follower_id;not null"`
+	FolloweeID int       `gorm:"column:followee_id;not null"`
+	CreatedAt  time.Time `gorm:"column:created_at;autoCreateTime"`
+	UpdatedAt  time.Time `gorm:"column:updated_at;autoUpdateTime"`
+	DeletedAt  time.Time `gorm:"column:deleted_at;autoDeleteTime"`
 
 	// Relations
-	Follower User `gorm:"foreignKey:FollowerID"`
-	Followee User `gorm:"foreignKey:FolloweeID"`
+	Follower User `gorm:"foreignKey:FollowerID;references:ID"`
+	Followee User `gorm:"foreignKey:FolloweeID;references:ID"`
 }
 
 func (Follow) TableName() string {

--- a/backend/api/infrastructure/persistence/follow_persistence.go
+++ b/backend/api/infrastructure/persistence/follow_persistence.go
@@ -62,3 +62,13 @@ func (p *FollowPersistence) FollowUser(followerID int, followeeID int) error {
 
 	return nil
 }
+
+func (p *FollowPersistence) UnfollowUser(followerID int, followeeID int) error {
+	if err := p.db.Where("follower_id = ? AND followee_id = ?", followerID, followeeID).
+		Delete(&model.Follow{}).Error; err != nil {
+		fmt.Printf("errror during creating new record to follows table: %v\n", err)
+		return err
+	}
+
+	return nil
+}

--- a/backend/api/infrastructure/persistence/follow_persistence.go
+++ b/backend/api/infrastructure/persistence/follow_persistence.go
@@ -22,7 +22,7 @@ func (p *FollowPersistence) GetFollowers(userID int) (*[]repository.FollowUserDT
 
 	if err := p.db.Model(&model.Follow{}).
 			Select("users.id, users.user_name, users.display_name, users.icon_image, follows.updated_at").
-			Joins("left join users on follows.followee_id = users.id").
+			Joins("left join users on follows.follower_id = users.id").
 			Where("follows.followee_id = ? AND follows.deleted_at IS NULL", userID).
 			Scan(&followers).Error;
 	err != nil {
@@ -38,7 +38,7 @@ func (p *FollowPersistence) GetFollowees(userID int) (*[]repository.FollowUserDT
 
 	if err := p.db.Model(&model.Follow{}).
 			Select("users.id, users.user_name, users.display_name, users.icon_image, follows.updated_at").
-			Joins("left join users on follows.follower_id = users.id").
+			Joins("left join users on follows.followee_id = users.id").
 			Where("follows.follower_id = ? AND follows.deleted_at IS NULL", userID).
 			Scan(&followees).Error;
 	err != nil {

--- a/backend/api/infrastructure/persistence/follow_persistence.go
+++ b/backend/api/infrastructure/persistence/follow_persistence.go
@@ -21,7 +21,7 @@ func (p *FollowPersistence) GetFollowers(userID int) (*[]repository.FollowUserDT
 	followers := []repository.FollowUserDTO{}
 
 	if err := p.db.Model(&model.Follow{}).
-			Select("users.id", "users.user_name", "users.user_name", "users.display_name", "users.icon_image", "follows.updated_at").
+			Select("users.id, users.user_name, users.display_name, users.icon_image, follows.updated_at").
 			Joins("left join users on follows.followee_id = users.id").
 			Where("follows.followee_id = ? AND follows.deleted_at IS NULL", userID).
 			Scan(&followers).Error;
@@ -37,7 +37,7 @@ func (p *FollowPersistence) GetFollowees(userID int) (*[]repository.FollowUserDT
 	followees := []repository.FollowUserDTO{}
 
 	if err := p.db.Model(&model.Follow{}).
-			Select("users.id, users.user_name, users.user_name, users.display_name, users.icon_image, follows.updated_at").
+			Select("users.id, users.user_name, users.display_name, users.icon_image, follows.updated_at").
 			Joins("left join users on follows.follower_id = users.id").
 			Where("follows.follower_id = ? AND follows.deleted_at IS NULL", userID).
 			Scan(&followees).Error;

--- a/backend/api/infrastructure/persistence/follow_persistence.go
+++ b/backend/api/infrastructure/persistence/follow_persistence.go
@@ -23,7 +23,7 @@ func (p *FollowPersistence) GetFollowers(userID int) (*[]repository.FollowUserDT
 	if err := p.db.Model(&model.Follow{}).
 			Select("users.id", "users.user_name", "users.user_name", "users.display_name", "users.icon_image", "follows.updated_at").
 			Joins("left join users on follows.followee_id = users.id").
-			Where("follows.followee_id = ?", userID).
+			Where("follows.followee_id = ? AND follows.deleted_at IS NULL", userID).
 			Scan(&followers).Error;
 	err != nil {
 		fmt.Printf("error during select from follows when getting followers (persistence): %v\n", err)
@@ -39,7 +39,7 @@ func (p *FollowPersistence) GetFollowees(userID int) (*[]repository.FollowUserDT
 	if err := p.db.Model(&model.Follow{}).
 			Select("users.id, users.user_name, users.user_name, users.display_name, users.icon_image, follows.updated_at").
 			Joins("left join users on follows.follower_id = users.id").
-			Where("follows.follower_id = ?", userID).
+			Where("follows.follower_id = ? AND follows.deleted_at IS NULL", userID).
 			Scan(&followees).Error;
 	err != nil {
 		fmt.Printf("error during select from follows when getting followees (persistence): %v\n", err)

--- a/backend/api/infrastructure/persistence/follow_persistence.go
+++ b/backend/api/infrastructure/persistence/follow_persistence.go
@@ -21,7 +21,7 @@ func (p *FollowPersistence) GetFollowers(userID int) (*[]repository.FollowUserDT
 	followers := []repository.FollowUserDTO{}
 
 	if err := p.db.Model(&model.Follow{}).
-			Select("users.id, users.user_name, users.display_name, users.icon_image, follows.updated_at").
+			Select("users.id AS user_id, users.user_name, users.display_name, users.icon_image, follows.updated_at").
 			Joins("left join users on follows.follower_id = users.id").
 			Where("follows.followee_id = ? AND follows.deleted_at IS NULL", userID).
 			Scan(&followers).Error;
@@ -37,7 +37,7 @@ func (p *FollowPersistence) GetFollowees(userID int) (*[]repository.FollowUserDT
 	followees := []repository.FollowUserDTO{}
 
 	if err := p.db.Model(&model.Follow{}).
-			Select("users.id, users.user_name, users.display_name, users.icon_image, follows.updated_at").
+			Select("users.id AS user_id, users.user_name, users.display_name, users.icon_image, follows.updated_at").
 			Joins("left join users on follows.followee_id = users.id").
 			Where("follows.follower_id = ? AND follows.deleted_at IS NULL", userID).
 			Scan(&followees).Error;

--- a/backend/api/infrastructure/repository/follow_repository.go
+++ b/backend/api/infrastructure/repository/follow_repository.go
@@ -8,11 +8,6 @@ type FollowUserDTO struct {
 	UpdatedAt	string	`json:"created_at"`
 }
 
-type FollowUpdateDTO struct {
-	FollowerID	int		`json:"follower_id"`
-	FolloweeID	int		`json:"followee_id"`
-}
-
 type FollowersRepository interface {
 	GetFollowers(userID int) (*[]FollowUserDTO, error)
 }

--- a/backend/api/usecase/service/follow_service.go
+++ b/backend/api/usecase/service/follow_service.go
@@ -44,3 +44,13 @@ func (s *FollowService) FollowUser(followerID int, followeeID int) error {
 	
 	return nil
 }
+
+func (s *FollowService) UnfollowUser(followerID int, followeeID int) error {
+	// TODO: APIを叩いた人が本人かSessionで確認する
+	if err := s.followPersistence.UnfollowUser(followerID, followeeID); err != nil {
+		fmt.Printf("error unfollowing user (service): %v\n", err)
+		return err
+	}
+	
+	return nil
+}


### PR DESCRIPTION
## issue
下記に該当issueを入れてください
- #85
- #64  


## 実装内容
-フォロー解除（DELETE follow/:follower_id/:followee_id）のAPIを新たに実装
-フォロワー取得（GET follower/:user_id）とフォロー中取得（followee/:user_id）が正しく実装されていないのに気づいたので修正

## 証跡
ここには、実装した結果がわかるスクリーンショットor動画を入れてください

## 備考
その他、レビュアーへのメッセージなどがあれば記述してください。
- APIが呼ばれた時にその本人がログインしているのか確認する必要あり