### PR TITLE
フォロー追加とフォロー削除時の条件を追加

### DIFF
--- a/backend/api/domain/model/follow.go
+++ b/backend/api/domain/model/follow.go
@@ -13,7 +13,7 @@ type Follow struct {
 	FolloweeID int       `gorm:"column:followee_id;not null"`
 	CreatedAt  time.Time `gorm:"column:created_at;autoCreateTime"`
 	UpdatedAt  time.Time `gorm:"column:updated_at;autoUpdateTime"`
-	DeletedAt  time.Time `gorm:"column:deleted_at;autoDeleteTime"`
+	DeletedAt  *time.Time `gorm:"column:deleted_at;autoDeleteTime"`
 
 	// Relations
 	Follower User `gorm:"foreignKey:FollowerID;references:ID"`

--- a/backend/api/infrastructure/persistence/follow_persistence.go
+++ b/backend/api/infrastructure/persistence/follow_persistence.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"fmt"
+	"errors"
 
 	"github.com/ayahiro1729/onpu/api/domain/model"
 	"github.com/ayahiro1729/onpu/api/infrastructure/repository"
@@ -50,11 +51,36 @@ func (p *FollowPersistence) GetFollowees(userID int) (*[]repository.FollowUserDT
 }
 
 func (p *FollowPersistence) FollowUser(followerID int, followeeID int) error {
+	// 既にフォロー関係がないか確認
+	var existingFollow model.Follow
+	err := p.db.Unscoped().Where("follower_id = ? AND followee_id = ?", followerID, followeeID).
+		First(&existingFollow).Error
+
+	if err == nil {
+		if existingFollow.DeletedAt != nil {
+			// 既に論理削除されたフォロー関係がある場合、deleted_atをnullにして復元
+			err = p.db.Unscoped().Model(&existingFollow).Update("deleted_at", nil).Error
+			if err != nil {
+				fmt.Printf("error during restoring follow relationship: %v\n", err)
+				return err
+			}
+			// 復元に成功したら、レコード追加操作は行わない
+			return nil
+		}
+		// 既にフォローしている場合
+		return fmt.Errorf("already following this user")
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		// レコードが存在しない(期待されている結果)以外のエラーが発生した場合
+		fmt.Printf("error during checking follow relationship: %v\n", err)
+		return err
+	}
+
 	follow := model.Follow{
 		FollowerID: followerID,
 		FolloweeID: followeeID,
 	}
 
+	// 新規フォロー関係をテーブルに追加
 	if err := p.db.Select("FollowerID", "FolloweeID").Create(&follow).Error; err != nil {
 		fmt.Printf("errror during creating new record to follows table: %v\n", err)
 		return err

--- a/backend/api/infrastructure/persistence/follow_persistence.go
+++ b/backend/api/infrastructure/persistence/follow_persistence.go
@@ -90,10 +90,20 @@ func (p *FollowPersistence) FollowUser(followerID int, followeeID int) error {
 }
 
 func (p *FollowPersistence) UnfollowUser(followerID int, followeeID int) error {
-	if err := p.db.Where("follower_id = ? AND followee_id = ?", followerID, followeeID).
-		Delete(&model.Follow{}).Error; err != nil {
+	result := p.db.Where("follower_id = ? AND followee_id = ?", followerID, followeeID).
+		Delete(&model.Follow{})
+	err := result.Error
+
+	// 削除中にエラーが発生した場合
+	if err != nil {
 		fmt.Printf("errror during creating new record to follows table: %v\n", err)
 		return err
+	}
+
+	// 削除したいレコードがなかった場合
+	if result.RowsAffected == 0 {
+		fmt.Printf("no follow relationship found", followerID, followeeID)
+		return fmt.Errorf("no follow relationship found")
 	}
 
 	return nil


### PR DESCRIPTION
## issue
下記に該当issueを入れてください
- #88


## 実装内容
- フォローするとき、既にフォロー関係があったらエラーを返す
- フォローするとき、同じユーザーの組み合わせの論理削除されたレコードがあったら、deleted_atをnullにすることでフォロー関係を復元
- フォロー解除するとき、削除対象のレコードがなかったらエラーを返す


## 証跡
ここには、実装した結果がわかるスクリーンショットor動画を入れてください
- ちゃんとPostmanでテストしました

## 備考
その他、レビュアーへのメッセージなどがあれば記述してください。
