### PR TITLE
フォロー欄とユーザー検索の修正

### DIFF
--- a/backend/api/infrastructure/persistence/user_persistence.go
+++ b/backend/api/infrastructure/persistence/user_persistence.go
@@ -42,7 +42,7 @@ func (p *UserPersistence) FindUsersByUserName(search_string string) (*[]reposito
 
 	if err := p.db.Model(&model.User{}).
 		Select("id AS user_id", "user_name", "display_name", "icon_image").
-		Where("user_name LIKE ?", "%"+search_string+"%").
+		Where("display_name LIKE ?", "%"+search_string+"%").
 		Scan(&users).Error; err != nil {
 		return nil, err
 	}

--- a/frontend/app/components/Followers.tsx
+++ b/frontend/app/components/Followers.tsx
@@ -7,11 +7,13 @@ export const Followers: React.FC<FollowerProps> = ({followers}) => {
     <div className="flex flex-col gap-4">
       <p className="text-2xl">Followers</p>
       { followers.length === 0 && <div>No followers found.</div> }
+      <div className="flex gap-2">
       { followers.map((follower, index) => (
         <Link to={`/user/${follower.user_id}`} key={index} className="flex items-center gap-2">
           <img src={follower.icon_image} className="w-10 h-10 rounded-full" />
         </Link>
       ))}
+      </div>
     </div>
   );
 }

--- a/frontend/app/components/Followings.tsx
+++ b/frontend/app/components/Followings.tsx
@@ -7,11 +7,13 @@ export const Followings: React.FC<FollowingsProps> = ({followings}) => {
     <div className="flex flex-col gap-4">
       <p className="text-2xl">Followings</p>
       { followings.length === 0 && <div>No followings found.</div> }
+      <div className="flex gap-2">
       { followings.map((following, index) => (
         <Link to={`/user/${following.user_id}`} key={index} className="flex items-center gap-2">
           <img src={following.icon_image} className="w-10 h-10 rounded-full" />
         </Link>
       ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## issue
下記に該当issueを入れてください
- #


## 実装内容
２次予選前に急いで修正したやつです！
-フォロワーとフォロー中の欄に複数のアイコンがあった時、アイコンが横並びになるように修正
- ユーザーを検索するときに、user_nameではなくdisplay_nameで検索するように修正

## 証跡
ここには、実装した結果がわかるスクリーンショットor動画を入れてください

## 備考
その他、レビュアーへのメッセージなどがあれば記述してください。
